### PR TITLE
Migrate npm publishing to Trusted Publisher and remove CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,0 @@
-exclude_patterns:
-  - "docs"
-  - "esm"
-  - "lib"

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,10 +1,13 @@
 name: Publish to NPM
 on:
   release:
-    types: [created]
+    types: [published]
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC authentication
+      contents: read   # Required for repository access
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -14,10 +17,10 @@ jobs:
           node-version: "20"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm to v11.6.0
+        run: npm install -g npm@11.6.0
       - run: npm ci
       - name: build binary
         run: npm run buildTS
       - name: Publish package on NPM 📦
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 [![build test](https://github.com/MasatoMakino/threejs-particle-waypoint/actions/workflows/ci_main.yml/badge.svg)](https://github.com/MasatoMakino/threejs-particle-waypoint/actions/workflows/ci_main.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/b14e7ead3dfae70d1e3f/maintainability)](https://codeclimate.com/github/MasatoMakino/threejs-particle-waypoint/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/b14e7ead3dfae70d1e3f/test_coverage)](https://codeclimate.com/github/MasatoMakino/threejs-particle-waypoint/test_coverage)
 
 [![ReadMe Card](https://github-readme-stats.vercel.app/api/pin/?username=MasatoMakino&repo=threejs-particle-waypoint&show_owner=true)](https://github.com/MasatoMakino/threejs-particle-waypoint)
 


### PR DESCRIPTION
## Summary

This PR migrates npm package publishing from token-based authentication to NPM Trusted Publisher with OIDC authentication and removes deprecated CodeClimate configurations.

## Changes

### NPM Trusted Publisher Migration
- ✅ Added OIDC permissions to GitHub Actions workflow (`id-token: write`, `contents: read`)
- ✅ Added npm upgrade step for latest OIDC support (v11.6.0)
- ✅ Removed NPM token authentication from workflow
- ✅ Fixed release trigger to use `published` instead of `created`

### CodeClimate Cleanup
- ✅ Deleted `.codeclimate.yml` configuration file
- ✅ Removed CodeClimate badges from README.md

## Security Improvements

- Enhanced security through OIDC authentication
- Provenance statements for package integrity
- Elimination of long-lived tokens
- Two-factor authentication requirement

## Testing

After merging, the migration can be tested by creating a release. The workflow should successfully publish to NPM using Trusted Publisher authentication.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Removed Code Climate maintainability and coverage badges from README.
- Chores
  - Expanded Code Climate analysis by removing exclusions.
- CI
  - Release workflow now triggers on published releases.
  - Added required permissions for OIDC and repository access.
  - Upgraded npm to 11.6.0 in the publish workflow.
  - Removed use of NODE_AUTH_TOKEN in publish step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->