### PR TITLE
fix: add Chrome SwiftShader args for CI WebGL rendering

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,8 +5,17 @@ export default defineConfig({
     browser: {
       enabled: true,
       provider: "webdriverio",
-      name: "chrome",
       headless: true,
+      instances: [
+        {
+          browser: "chrome",
+          capabilities: {
+            "goog:chromeOptions": {
+              args: ["--use-gl=angle", "--use-angle=swiftshader"],
+            },
+          },
+        },
+      ],
     },
     coverage: {
       provider: "istanbul",


### PR DESCRIPTION
## Summary

Chrome 137+ removed automatic SwiftShader fallback for software WebGL rendering. GitHub Actions runner image updated Chrome 143→144, causing WebGL context creation failures in headless browser tests.

**Changes:**
- Add `--use-gl=angle` and `--use-angle=swiftshader` Chrome args via `capabilities` in `instances`
- Migrate from deprecated `name` field to `instances` array for Vitest 3.x browser config

**Unchanged:**
- Test logic, coverage settings, pool options

## Test Plan

- [ ] CI browser tests pass with Chrome 144+ on `ubuntu-latest`