### PR TITLE
ci: migrate GitHub Pages to official actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,11 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-# Allow only one concurrent deployment
-concurrency:
-  group: pages-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
   build-pages:
     runs-on: ubuntu-latest
@@ -42,6 +37,10 @@ jobs:
           path: ./docs
 
   deploy-pages:
+    # Allow only one concurrent deployment
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Summary

Migrate GitHub Pages deployment from third-party `peaceiris/actions-gh-pages` to official GitHub Actions (`actions/upload-pages-artifact` + `actions/deploy-pages`).

**Scope:**
- Replace `peaceiris/actions-gh-pages` with official `actions/upload-pages-artifact` + `actions/deploy-pages`
- Split single job into 2 jobs: `build-pages` (build + upload) and `deploy-pages` (deploy)
- Reduce permissions: `contents: write` to `contents: read` (build job)
- Add OIDC-based deployment with `pages: write` + `id-token: write` (deploy job)
- Add concurrency group to prevent parallel deployments
- All actions pinned to commit SHA

**Unchanged:**
- Build commands (`npm run build`, `npm run typedocs`)
- Node.js version (22)
- Trigger conditions (push/PR to main)
- Output directory (`./docs`)

## Post-merge manual steps

1. Change Pages source to "GitHub Actions" via repository settings (requires Administration permission)
2. Update branch protection required status checks: remove `publish`, add `build-pages`

## Test plan

- [ ] `build-pages` job succeeds on this PR
- [ ] After merge: `deploy-pages` job deploys to GitHub Pages
- [ ] Site loads at GitHub Pages URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured deployment workflow into separate build and deploy stages for clearer, more reliable releases.
  * Added concurrency control to prevent simultaneous deployments, improving stability.
  * Deployment now runs only after successful build and is gated to the main branch, reducing failed releases.
  * Workflow now triggers on pull requests and includes adjusted permissions to support secure deploy flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->