### PR TITLE
fix: remove broken ReadMe Card from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 [![build test](https://github.com/MasatoMakino/threejs-particle-waypoint/actions/workflows/ci_main.yml/badge.svg)](https://github.com/MasatoMakino/threejs-particle-waypoint/actions/workflows/ci_main.yml)
 
-[![ReadMe Card](https://github-readme-stats.vercel.app/api/pin/?username=MasatoMakino&repo=threejs-particle-waypoint&show_owner=true)](https://github.com/MasatoMakino/threejs-particle-waypoint)
-
 ## Demo
 
 [Demo Page](https://masatomakino.github.io/threejs-particle-waypoint/demo/)


### PR DESCRIPTION
## Summary

Remove the non-rendering github-readme-stats card image from README.

## Scope

**Changes:**
- Remove broken ReadMe Card badge/link from README.md

**Unchanged:**
- All other README content (badges, demo link, API docs link)

## Test Plan

- Verify README renders correctly on GitHub after merge
- Verify branch protection ruleset enforces CI checks on this PR

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cleaned up project documentation by removing a badge line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->