### PR TITLE
chore: add .op directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ typings/
 docs/
 lib/
 esm/
+
+# 1Password CLI
+.op/


### PR DESCRIPTION
## Summary

Prevent 1Password CLI temporary scope configuration (`.op/`) from being committed to the repository.

**Changes:**
- Add `.op/` to `.gitignore`

**Unchanged:**
- All other gitignore rules

## Test plan

- Verify `.op/` directory is excluded from git tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->