### PR TITLE
ci: migrate npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -19,6 +19,7 @@ jobs:
       REF: ${{ github.ref }}
       TAG: ${{ github.ref_name }}
       REPO: ${{ github.repository }}
+      DISPATCH_SHA: ${{ github.sha }}
     outputs:
       version: ${{ steps.extract.outputs.version }}
       commit_sha: ${{ steps.resolve_tag.outputs.sha }}
@@ -56,7 +57,11 @@ jobs:
               exit 1
             }
           fi
-          echo "Tag $TAG exists at commit $COMMIT_SHA"
+          if [ "$COMMIT_SHA" != "$DISPATCH_SHA" ]; then
+            echo "::error::Tag commit ($COMMIT_SHA) differs from dispatch commit ($DISPATCH_SHA). Tag may have been force-moved."
+            exit 1
+          fi
+          echo "Tag $TAG verified at commit $COMMIT_SHA"
           echo "sha=$COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Verify GitHub Release is published


### PR DESCRIPTION
## Summary

Migrate npm publish workflow from release-event trigger to workflow_dispatch + OIDC Trusted Publishing.

## Scope

**Changes:**
- Replace single-job release-triggered workflow with two-job structure (validate + publish)
- Add validate job: tag format, tag existence, release status, version extraction
- Add publish job: `npm-publish` Environment gate, OIDC provenance (`--provenance`)
- Switch trigger from `release: published` to `workflow_dispatch` with tag input
- Use `env:` context for all `${{ }}` expressions in `run:` blocks (script injection prevention)
- Pin actions to commit SHA (`actions/checkout` v6.0.2, `actions/setup-node` v6.3.0)

**Unchanged:**
- Build command (`npm run buildTS`)
- Node.js version (22)
- npm OIDC upgrade step (`npm@^11.10.0`)
- Package access level (`public`)

## Post-Merge Manual Steps

1. ~~GitHub Environment `npm-publish` creation~~ (already done via API)
2. ~~npm Trusted Publisher configuration~~ (already done)
3. Delete existing npm automation token after first successful OIDC publish

## Test Plan

- [ ] CI passes on this PR
- [ ] After merge: trigger `workflow_dispatch` with an existing tag to verify validate job
- [ ] First release: confirm publish job completes with OIDC provenance

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured npm publishing into a two-stage validate-and-publish workflow, triggered manually
  * Validation now checks tag format (vX.Y.Z), resolves tag to a commit, ensures a published release, and exposes version/commit outputs
  * Publish stage checks out the resolved commit, verifies package version, installs dependencies, builds, and publishes with provenance
  * Updated runners and tightened workflow permissions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->