### PR TITLE
fix(npm_publish): improve error handling and API stderr visibility

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -42,8 +42,8 @@ jobs:
         id: resolve_tag
         run: |
           TAG_REF=$(gh api "repos/${REPO}/git/ref/tags/${TAG}" \
-            --jq '.object.sha + " " + .object.type' 2>/dev/null) || {
-            echo "::error::Tag $TAG does not exist in repository"
+            --jq '.object.sha + " " + .object.type') || {
+            echo "::error::Failed to look up tag $TAG"
             exit 1
           }
           TAG_OBJ_SHA=$(echo "$TAG_REF" | cut -d' ' -f1)
@@ -52,7 +52,7 @@ jobs:
             COMMIT_SHA="$TAG_OBJ_SHA"
           else
             COMMIT_SHA=$(gh api "repos/${REPO}/git/tags/${TAG_OBJ_SHA}" \
-              --jq '.object.sha' 2>/dev/null) || {
+              --jq '.object.sha') || {
               echo "::error::Failed to resolve annotated tag $TAG"
               exit 1
             }


### PR DESCRIPTION
## Summary

Sync npm_publish.yml with latest template improvements from npm-oidc-infra-init skill.

**Changes:**
- Remove `2>/dev/null` stderr suppression from `gh api` calls in validate job — API errors are now visible in workflow logs for debugging
- Update error message from tag-specific to generic phrasing — handles 404, network errors, and other API failures

**Unchanged:**
- SHA-pinned action versions (already ahead of template)
- Build command (`npm run buildTS`)
- All validation logic and job structure

## Test Plan

- [ ] CI passes
- [ ] Verify validate job error paths by dispatching from a non-tag ref (should show improved error messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)